### PR TITLE
fix: Add default export to BankDashboard component

### DIFF
--- a/pages/BankDashboard.tsx
+++ b/pages/BankDashboard.tsx
@@ -70,3 +70,5 @@ const BankDashboard: React.FC = () => {
     </>
   );
 };
+
+export default BankDashboard;


### PR DESCRIPTION
The Netlify build was failing due to a TypeScript error indicating that the `BankDashboard` component did not have a default export. This commit adds the missing default export to `pages/BankDashboard.tsx`, which resolves the build error.