### PR TITLE
feat: Redesign QBank dashboard with tag statistics

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -10,7 +10,7 @@ interface LayoutProps {
 const navItems = [
     { to: '/', text: 'Dashboard', icon: LayoutDashboard },
     { to: '/bank', text: 'Question Bank', icon: Library },
-    { to: '/srs-review', text: 'Review', icon: BrainCircuit },
+    { to: '/review', text: 'Review', icon: BrainCircuit },
     { to: '/exams', text: 'Exams', icon: PencilRuler }
 ];
 

--- a/components/TagStatsWidget.tsx
+++ b/components/TagStatsWidget.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Bookmark, Flame, AlertTriangle, RefreshCw } from 'lucide-react';
+
+interface TagStats {
+  bookmarked: number;
+  hard: number;
+  revise: number;
+  mistaked: number;
+}
+
+interface TagStatsWidgetProps {
+  stats: TagStats;
+}
+
+const statItems = [
+  { key: 'bookmarked', label: 'Bookmarked', icon: Bookmark, color: 'text-yellow-500' },
+  { key: 'hard', label: 'Marked as Hard', icon: Flame, color: 'text-red-500' },
+  { key: 'revise', label: 'Marked for Revision', icon: RefreshCw, color: 'text-blue-500' },
+  { key: 'mistaked', label: 'Mistaken', icon: AlertTriangle, color: 'text-orange-500' },
+];
+
+export const TagStatsWidget: React.FC<TagStatsWidgetProps> = ({ stats }) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Tagged Questions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-4">
+          {statItems.map(item => (
+            <div key={item.key} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+              <item.icon className={`h-6 w-6 ${item.color}`} />
+              <div>
+                <p className="text-2xl font-bold">{stats[item.key as keyof TagStats]}</p>
+                <p className="text-sm text-muted-foreground">{item.label}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/context/AnalyticsContext.tsx
+++ b/context/AnalyticsContext.tsx
@@ -23,6 +23,7 @@ interface AnalyticsContextType {
   // Derived Analytics
   allQuestions: MCQ[];
   dueReviewQuestions: StudyQuestion[];
+  tagStats: { bookmarked: number; hard: number; revise: number; mistaked: number; };
   performanceBySubject: Array<{ subject: string; correct: number; total: number; accuracy: number; }>;
   topicsToWatch: Array<{ subject: string; accuracy: number; }>;
   recentActivity: Activity[];
@@ -121,6 +122,17 @@ export const AnalyticsProvider = ({ children }: { children: ReactNode }) => {
   // --- Computational Logic & Derived State (The "Engine") ---
 
   const allQuestions = useMemo(() => batches.flatMap(b => b.questions), [batches]);
+
+  const tagStats = useMemo(() => {
+    const stats = { bookmarked: 0, hard: 0, revise: 0, mistaked: 0 };
+    allQuestions.forEach(q => {
+      if (q.tags.bookmarked) stats.bookmarked++;
+      if (q.tags.hard) stats.hard++;
+      if (q.tags.revise) stats.revise++;
+      if (q.lastAttemptCorrect === false) stats.mistaked++;
+    });
+    return stats;
+  }, [allQuestions]);
 
   const dueReviewQuestions = useMemo(() => {
     const today = new Date();
@@ -301,7 +313,7 @@ export const AnalyticsProvider = ({ children }: { children: ReactNode }) => {
     studyHistory, addStudySession,
     examHistory, addExamSession, getExamById,
     goal, setGoal,
-    allQuestions, dueReviewQuestions, performanceBySubject, topicsToWatch, recentActivity, lastSession, overallStats,
+    allQuestions, dueReviewQuestions, tagStats, performanceBySubject, topicsToWatch, recentActivity, lastSession, overallStats,
     statsBySubject, statsByPlatform, exportData, importData, weeklyGoalProgress, performanceOverTime
   };
 

--- a/pages/BankDashboard.tsx
+++ b/pages/BankDashboard.tsx
@@ -6,19 +6,17 @@ import { PlusCircle, Zap } from 'lucide-react';
 import StudyPanel from '../components/StudyPanel';
 import { PerformanceCharts } from '../components/PerformanceCharts';
 import { GoalTrackerWidget } from '../components/GoalTrackerWidget';
-import { RecentActivityWidget } from '../components/RecentActivityWidget';
 import { TopicsToWatchWidget } from '../components/TopicsToWatchWidget';
-import { LastSessionWidget } from '../components/LastSessionWidget';
+import { TagStatsWidget } from '../components/TagStatsWidget';
 
 import { Button } from '../components/ui/button';
 
 const BankDashboard: React.FC = () => {
   const { 
-    recentActivity, 
     topicsToWatch,
-    lastSession,
     performanceOverTime,
-    performanceBySubject
+    performanceBySubject,
+    tagStats
   } = useAnalytics();
   
   const [isPanelOpen, setIsPanelOpen] = useState(false);
@@ -58,15 +56,16 @@ const BankDashboard: React.FC = () => {
           {/* Right sidebar for smaller widgets */}
           <div className="space-y-6">
             <GoalTrackerWidget />
-            <LastSessionWidget lastSession={lastSession} />
+            <TagStatsWidget stats={tagStats} />
           </div>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <RecentActivityWidget activities={recentActivity} />
           <TopicsToWatchWidget topics={topicsToWatch} />
         </div>
       </div>
     </>
   );
 };
+
+export default BankDashboard;

--- a/pages/SrsReviewSession.tsx
+++ b/pages/SrsReviewSession.tsx
@@ -16,7 +16,7 @@ const SrsReviewSession: React.FC = () => {
   const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string>>({});
   const [sessionEnded, setSessionEnded] = useState(false);
 
-  const questions = useMemo(() => dueReviewQuestions, [dueReviewQuestions]);
+  const questions = useMemo(() => dueReviewQuestions || [], [dueReviewQuestions]);
   const currentQuestion = questions[currentQuestionIndex];
   const selectedOption = currentQuestion ? selectedAnswers[currentQuestion.id] : undefined;
   


### PR DESCRIPTION
This commit implements a user request to redesign the QBank dashboard.

- The 'Recent Activity' and 'Last Session' widgets have been removed to streamline the interface.
- A new 'Tag Statistics' widget has been added. This widget displays the number of questions the user has marked as 'Bookmarked', 'Hard', and 'For Revision', as well as the number of questions they have previously answered incorrectly ('Mistaken').
- The application's analytics context has been updated to compute these statistics from the user's question data.