### PR TITLE
feat: Add exam history and improve PWA layout

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -18,37 +18,39 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const { theme, toggleTheme } = useTheme();
 
   return (
-    <div className="flex h-screen bg-background">
-      <aside className="w-56 flex-shrink-0 border-r bg-card flex flex-col">
-        <div className="flex items-center gap-2.5 px-4 h-20 border-b">
-            <BookOpenCheck className="h-7 w-7 text-primary" />
-            <h1 className="text-xl font-bold text-foreground tracking-tighter">E-Qbank</h1>
-        </div>
-        
-        <nav className="flex flex-col gap-1 p-4 flex-grow">
-            {navItems.map(item => (
-                <NavItem key={item.to} to={item.to} icon={item.icon}>{item.text}</NavItem>
-            ))}
-        </nav>
+    <div className="fixed inset-0 overflow-hidden">
+      <div className="flex h-full bg-background">
+        <aside className="w-56 flex-shrink-0 border-r bg-card flex flex-col">
+          <div className="flex items-center gap-2.5 px-4 h-20 border-b">
+              <BookOpenCheck className="h-7 w-7 text-primary" />
+              <h1 className="text-xl font-bold text-foreground tracking-tighter">E-Qbank</h1>
+          </div>
 
-        <div className="p-4 border-t">
-             <Button 
-                variant="ghost" 
-                onClick={toggleTheme}
-                aria-label="Toggle theme"
-                className="w-full justify-start gap-3 px-3 text-muted-foreground hover:text-foreground"
-              >
-                <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-                <span>{theme === 'dark' ? 'Light' : 'Dark'} Mode</span>
-              </Button>
+          <nav className="flex flex-col gap-1 p-4 flex-grow">
+              {navItems.map(item => (
+                  <NavItem key={item.to} to={item.to} icon={item.icon}>{item.text}</NavItem>
+              ))}
+          </nav>
+
+          <div className="p-4 border-t">
+              <Button
+                  variant="ghost"
+                  onClick={toggleTheme}
+                  aria-label="Toggle theme"
+                  className="w-full justify-start gap-3 px-3 text-muted-foreground hover:text-foreground"
+                >
+                  <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                  <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                  <span>{theme === 'dark' ? 'Light' : 'Dark'} Mode</span>
+                </Button>
+          </div>
+        </aside>
+
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <main className="flex-1 overflow-y-auto p-10">
+              {children}
+          </main>
         </div>
-      </aside>
-      
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <main className="flex-1 overflow-y-auto p-10">
-            {children}
-        </main>
       </div>
     </div>
   );

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
     <title>E-Qbank</title>
     <link rel="manifest" href="/manifest.json" />
 <script type="importmap">

--- a/pages/ExamResults.tsx
+++ b/pages/ExamResults.tsx
@@ -5,6 +5,7 @@ import { MCQ } from '../types';
 import { CheckCircle, XCircle, Clock, Hash, Percent, Bookmark, Flame, RefreshCw } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
+import { ExamHistoryTable } from '../components/ExamHistoryTable';
 
 const ExamResults: React.FC = () => {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -120,6 +121,11 @@ const ExamResults: React.FC = () => {
           );
         })}
       </div>
+      <div className="mt-16">
+        <h2 className="text-3xl font-bold text-center mb-8 gradient-text">Overall Exam History</h2>
+        <ExamHistoryTable />
+      </div>
+
       <div className="mt-8 text-center">
         <Button size="lg" asChild>
           <Link to="/exams">Create Another Exam</Link>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,12 +1,41 @@
-
 {
   "short_name": "E-Qbank",
   "name": "E-Qbank: Medical MCQ Practice",
   "icons": [
     {
+      "src": "/icons/icon-72x72.png",
+      "type": "image/png",
+      "sizes": "72x72"
+    },
+    {
+      "src": "/icons/icon-96x96.png",
+      "type": "image/png",
+      "sizes": "96x96"
+    },
+    {
+      "src": "/icons/icon-128x128.png",
+      "type": "image/png",
+      "sizes": "128x128"
+    },
+    {
+      "src": "/icons/icon-144x144.png",
+      "type": "image/png",
+      "sizes": "144x144"
+    },
+    {
+      "src": "/icons/icon-152x152.png",
+      "type": "image/png",
+      "sizes": "152x152"
+    },
+    {
       "src": "/icons/icon-192x192.png",
       "type": "image/png",
       "sizes": "192x192"
+    },
+    {
+      "src": "/icons/icon-384x384.png",
+      "type": "image/png",
+      "sizes": "384x384"
     },
     {
       "src": "/icons/icon-512x512.png",
@@ -16,6 +45,8 @@
   ],
   "start_url": ".",
   "display": "standalone",
+  "orientation": "any",
+  "scope": "/",
   "theme_color": "#1e3a8a",
   "background_color": "#f1f5f9"
 }


### PR DESCRIPTION
This commit addresses two user requests:

1.  Adds the existing `ExamHistoryTable` component to the `pages/ExamResults.tsx` page. This allows users to view their exam history directly from the results screen, providing better context for their performance.

2.  Improves the Progressive Web App (PWA) experience and layout stability by:
    -   Making the main layout fixed to the viewport to prevent unexpected scrolling.
    -   Updating the viewport meta tag to disable user scaling.
    -   Enhancing the `manifest.json` with more icons and an orientation property.