### PR TITLE
fix: resolve build errors

### DIFF
--- a/components/ReviewSessionSummary.tsx
+++ b/components/ReviewSessionSummary.tsx
@@ -81,4 +81,3 @@ const ReviewSessionSummary: React.FC<ReviewSessionSummaryProps> = ({
 
 
 export default ReviewSessionSummary;
-in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pgqbank",
+  "name": "e-qbank",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pgqbank",
+      "name": "e-qbank",
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^0.12.0",

--- a/pages/AddQuestions.tsx
+++ b/pages/AddQuestions.tsx
@@ -89,7 +89,7 @@ const AddQuestions: React.FC = () => {
       questions: questionsToSave.map((mcq): MCQ => ({
         id: uuidv4(),
         ...mcq,
-        tags: { bookmarked: false, hard: false, revise: false },
+        tags: { bookmarked: false, hard: false, revise: false, mistaked: false },
         lastAttemptCorrect: null,
         srsLevel: 0,
         nextReviewDate: new Date().toISOString(),

--- a/types.ts
+++ b/types.ts
@@ -8,6 +8,7 @@ export interface MCQ {
     bookmarked: boolean;
     hard: boolean;
     revise: boolean;
+    mistaked: boolean;
   };
   notes?: string;
   lastAttemptCorrect: boolean | null; // null: unattempted, true: correct, false: incorrect


### PR DESCRIPTION
The Netlify deployment was failing due to TypeScript errors in the codebase. This commit fixes the following errors:

1. A stray 'in' was present in `components/ReviewSessionSummary.tsx`, causing a syntax error.
2. The `Tag` type in `types.ts` included a 'mistaked' tag, but the `MCQ` interface's `tags` property was missing it. This has been added.
3. The creation of new `MCQ` objects in `pages/AddQuestions.tsx` was missing the new `mistaked` tag property. This has been added.