### PR TITLE
feat: Revamp Exam Session UI and address feedback

### DIFF
--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from './ui/dialog';
+import { Button } from './ui/button';
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+}
+
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ isOpen, onClose, onConfirm, title, description }) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="glass-card text-white" style={{ background: 'rgba(10, 10, 10, 0.8)' }}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={onClose} variant="outline">Cancel</Button>
+          <Button onClick={onConfirm} variant="destructive">Confirm</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ConfirmationModal;

--- a/components/CreateExamPanel.tsx
+++ b/components/CreateExamPanel.tsx
@@ -1,0 +1,222 @@
+import React, { useState } from 'react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import { Badge } from './ui/badge';
+import PreviewQuestionsModal from './PreviewQuestionsModal';
+import { MultiSelect, MultiSelectOption } from './ui/MultiSelect';
+import { ExamConfig } from '../pages/ExamSetup';
+import { Bookmark } from 'lucide-react';
+
+import { ExamQuestion } from '../types';
+
+interface CreateExamPanelProps {
+  config: ExamConfig;
+  onConfigChange: (newConfig: Partial<ExamConfig>) => void;
+  availableSubjects: MultiSelectOption[];
+  startExam: () => void;
+  availableQuestions: number;
+  savePreset: () => void;
+  filteredQuestions: ExamQuestion[];
+}
+
+const TAGS = ["High-Yield", "Image-Based", "Unattempted", "Hard"];
+
+const CreateExamPanel: React.FC<CreateExamPanelProps> = ({
+  config,
+  onConfigChange,
+  availableSubjects,
+  startExam,
+  availableQuestions,
+  savePreset,
+}) => {
+  const [isPreviewModalOpen, setPreviewModalOpen] = useState(false);
+
+  const createRipple = (event: React.MouseEvent<HTMLElement>) => {
+    const element = event.currentTarget;
+    const circle = document.createElement("span");
+    const diameter = Math.max(element.clientWidth, element.clientHeight);
+    const radius = diameter / 2;
+
+    circle.style.width = circle.style.height = `${diameter}px`;
+    circle.style.left = `${event.clientX - element.getBoundingClientRect().left - radius}px`;
+    circle.style.top = `${event.clientY - element.getBoundingClientRect().top - radius}px`;
+    circle.classList.add("ripple");
+
+    const ripple = element.getElementsByClassName("ripple")[0];
+    if (ripple) {
+      ripple.remove();
+    }
+    element.appendChild(circle);
+  };
+
+  const handleClearFilters = () => {
+    onConfigChange({
+      examType: 'full-mock',
+      subjects: [],
+      chapters: [],
+      difficulty: 50,
+      numQuestions: 50,
+      tags: [],
+    });
+  };
+
+  const handleTagToggle = (tag: string) => {
+    const newTags = config.tags.includes(tag)
+      ? config.tags.filter((t) => t !== tag)
+      : [...config.tags, tag];
+    onConfigChange({ tags: newTags });
+  };
+
+  return (
+    <>
+      <div
+        className="glass-card w-full p-6 relative overflow-hidden"
+        style={{
+          height: '450px',
+          background: 'linear-gradient(135deg, #0A0A0A, #1A1A1A)',
+          borderRadius: '16px',
+          boxShadow: '0 4px 8px rgba(0,0,0,0.2)',
+        }}
+      >
+        <div className="flex flex-col h-full">
+          <header className="mb-4 flex justify-between items-center">
+            <h2 className="text-2xl font-bold text-white" style={{ fontFamily: 'SF Pro Display, sans-serif' }}>
+              Create New Exam
+            </h2>
+            <div className="text-sm text-gray-400" aria-live="polite">
+              {availableQuestions} Questions Available
+            </div>
+          </header>
+
+          <main className="flex-grow grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 overflow-y-auto pr-2">
+            {/* Column 1 */}
+            <div className="space-y-4">
+              <div className="flex items-center gap-4">
+                <Label htmlFor="exam-type" className="w-1/3 text-right text-gray-300">Exam Type</Label>
+                <Select value={config.examType} onValueChange={(value) => onConfigChange({ examType: value })}>
+                  <SelectTrigger id="exam-type" className="neumorphic-input w-2/3" aria-label="Select Exam Type">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="full-mock">Full Mock</SelectItem>
+                    <SelectItem value="subject-specific">Subject-Specific</SelectItem>
+                    <SelectItem value="quick-test">Quick Test</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-4">
+                <Label htmlFor="subjects" className="w-1/3 text-right text-gray-300">Subjects</Label>
+                <MultiSelect
+                  options={availableSubjects}
+                  selected={config.subjects}
+                  onChange={(selected) => onConfigChange({ subjects: selected })}
+                  className="neumorphic-input w-2/3"
+                  placeholder="Select Subjects"
+                  aria-label="Select Subjects for Exam"
+                />
+              </div>
+              <div className="flex items-center gap-4">
+                <Label htmlFor="chapters" className="w-1/3 text-right text-gray-300">Chapters</Label>
+                <Select disabled>
+                  <SelectTrigger id="chapters" className="neumorphic-input w-2/3">
+                    <SelectValue placeholder="Select Chapters (coming soon)" />
+                  </SelectTrigger>
+                </Select>
+              </div>
+            </div>
+
+            {/* Column 2 */}
+            <div className="space-y-4">
+              <div className="flex items-center gap-4">
+                <Label htmlFor="difficulty" className="w-1/3 text-right text-gray-300">Difficulty</Label>
+                <div className="w-2/3 flex items-center gap-2">
+                  <span className="text-gray-400">Easy</span>
+                  <input
+                    id="difficulty"
+                    type="range"
+                    min="0"
+                    max="100"
+                    value={config.difficulty}
+                    onChange={(e) => onConfigChange({ difficulty: Number(e.target.value) })}
+                    className="neumorphic-slider w-full"
+                    aria-label="Select difficulty"
+                  />
+                  <span className="text-gray-400">Hard</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-4">
+                <Label htmlFor="num-questions" className="w-1/3 text-right text-gray-300">Questions</Label>
+                <Input
+                  id="num-questions"
+                  type="number"
+                  value={config.numQuestions}
+                  onChange={(e) => onConfigChange({ numQuestions: Number(e.target.value) })}
+                  className="neumorphic-input w-2/3"
+                  min="10"
+                  max={availableQuestions > 0 ? availableQuestions : 200}
+                  step="10"
+                  aria-label="Number of questions"
+                />
+              </div>
+              <div className="flex items-center gap-4">
+                <Label className="w-1/3 text-right text-gray-300">Tags</Label>
+                <div className="w-2/3 flex flex-wrap gap-2">
+                  {TAGS.map(tag => (
+                    <Badge
+                      key={tag}
+                      variant={config.tags.includes(tag) ? "default" : "outline"}
+                      onClick={(e) => {
+                        handleTagToggle(tag);
+                        createRipple(e);
+                      }}
+                      className="cursor-pointer relative overflow-hidden"
+                    >
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </main>
+
+          <footer className="mt-auto pt-4 flex justify-between items-center gap-4">
+            <Button variant="ghost" onClick={(e) => {savePreset(); createRipple(e);}}><Bookmark className="mr-2 h-4 w-4" /> Save Preset</Button>
+            <div className="flex justify-center items-center gap-4">
+              <Button
+                className="neumorphic-button relative overflow-hidden"
+                onClick={(e) => {startExam(); createRipple(e);}}
+                disabled={availableQuestions === 0}
+              >
+                Start Exam
+              </Button>
+              <Button
+                variant="outline"
+                className="neumorphic-button relative overflow-hidden"
+                onClick={(e) => {setPreviewModalOpen(true); createRipple(e);}}
+              >
+                Preview Questions
+              </Button>
+              <Button
+                variant="outline"
+                className="neumorphic-button relative overflow-hidden"
+                onClick={(e) => {handleClearFilters(); createRipple(e);}}
+                style={{borderColor: 'hsl(var(--destructive))', color: 'hsl(var(--destructive))'}}
+              >
+                Clear Filters
+              </Button>
+            </div>
+          </footer>
+        </div>
+      </div>
+      <PreviewQuestionsModal
+        isOpen={isPreviewModalOpen}
+        onClose={() => setPreviewModalOpen(false)}
+        questions={filteredQuestions.slice(0, 10).map(q => ({ id: q.id, text: q.question }))}
+      />
+    </>
+  );
+};
+
+export default CreateExamPanel;

--- a/components/NavItem.tsx
+++ b/components/NavItem.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom';
 
 export const NavItem: React.FC<{ to: string, children: React.ReactNode, icon: React.ElementType }> = ({ to, children, icon: Icon }) => {
     const navLinkClass = ({ isActive }: { isActive: boolean }) =>
-    `flex items-center gap-4 px-4 h-[60px] rounded-lg text-lg font-bold transition-colors card-tilt ${
+    `flex items-center gap-4 px-4 h-[60px] rounded-lg text-lg font-bold transition-colors ${
       isActive
         ? 'bg-primary/20 text-primary animate-pulse'
         : 'text-muted-foreground hover:bg-primary/10 hover:text-primary'

--- a/components/PreviewQuestionsModal.tsx
+++ b/components/PreviewQuestionsModal.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from './ui/dialog';
+import { Button } from './ui/button';
+
+interface PreviewQuestionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  questions: { id: string; text: string }[];
+}
+
+const PreviewQuestionsModal: React.FC<PreviewQuestionsModalProps> = ({ isOpen, onClose, questions }) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="glass-card text-white" style={{ background: 'rgba(10, 10, 10, 0.8)' }}>
+        <DialogHeader>
+          <DialogTitle>Preview Questions</DialogTitle>
+          <DialogDescription>
+            Here are some of the questions that match your filter criteria.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <ul className="space-y-2">
+            {questions.map((q) => (
+              <li key={q.id} className="p-2 border-b border-gray-700">
+                {q.text}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose} variant="outline">Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PreviewQuestionsModal;

--- a/components/QuickReviewModal.tsx
+++ b/components/QuickReviewModal.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from './ui/dialog';
+import { Button } from './ui/button';
+import { cn } from '../lib/utils';
+import type { ExamQuestion } from '../types';
+
+interface QuickReviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  questions: ExamQuestion[];
+  answers: Record<string, string>;
+  markedForReview: string[];
+  currentIndex: number;
+  onQuestionSelect: (index: number) => void;
+}
+
+const QuickReviewModal: React.FC<QuickReviewModalProps> = ({
+  isOpen,
+  onClose,
+  questions,
+  answers,
+  markedForReview,
+  currentIndex,
+  onQuestionSelect
+}) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="glass-card text-white" style={{ background: 'rgba(10, 10, 10, 0.8)' }}>
+        <DialogHeader>
+          <DialogTitle>Quick Review</DialogTitle>
+          <DialogDescription>Jump to any question.</DialogDescription>
+        </DialogHeader>
+        <div className="py-4 grid grid-cols-5 gap-2">
+          {questions.map((q, index) => {
+            const isMarked = markedForReview.includes(q.id);
+            const isAnswered = answers[q.id] !== undefined;
+            const isCurrent = index === currentIndex;
+
+            let statusClass = 'bg-gray-700 hover:bg-gray-600';
+            if (isAnswered) statusClass = 'bg-blue-500 hover:bg-blue-400';
+            if (isMarked) statusClass = 'bg-yellow-500 hover:bg-yellow-400';
+            if (isCurrent) statusClass = 'ring-2 ring-white';
+
+            return (
+              <button
+                key={q.id}
+                onClick={() => {
+                  onQuestionSelect(index);
+                  onClose();
+                }}
+                className={cn("h-12 w-12 rounded-full flex items-center justify-center font-bold", statusClass)}
+              >
+                {index + 1}
+              </button>
+            );
+          })}
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose} variant="outline">Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default QuickReviewModal;

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "glass-card card-tilt rounded-lg border-2 bg-card text-card-foreground shadow-premium hover:shadow-bioluminescent-glow",
+      "glass-card rounded-lg border-2 bg-card text-card-foreground shadow-premium hover:shadow-bioluminescent-glow",
         
       className
     )}

--- a/index.css
+++ b/index.css
@@ -251,6 +251,10 @@
     box-shadow: 3px 3px 6px #000000, -3px -3px 6px #2a2a2a;
   }
 
+.neumorphic-slider::-webkit-slider-thumb {
+  background: #00A8FF;
+}
+
   .neumorphic-button {
     background-color: hsl(var(--background));
     border: 1px solid hsl(var(--border) / 0.2);
@@ -315,15 +319,6 @@
   transform: scale(0);
   animation: ripple 600ms linear;
   background-color: rgba(255, 255, 255, 0.7);
-}
-
-.card-tilt {
-  transition: transform 0.5s;
-  transform-style: preserve-3d;
-}
-
-.card-tilt:hover {
-  transform: perspective(1000px) rotateX(5deg) rotateY(5deg) scale3d(1.05, 1.05, 1.05);
 }
 
 .float-label-input {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,3 +24,17 @@ export function formatDistanceToNow(date: Date): string {
   }
   return 'today';
 }
+
+export function debounce<F extends (...args: any[]) => any>(func: F, waitFor: number) {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  const debounced = (...args: Parameters<F>) => {
+    if (timeout !== null) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+    timeout = setTimeout(() => func(...args), waitFor);
+  };
+
+  return debounced as (...args: Parameters<F>) => void;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,10 @@
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
+        "@use-gesture/react": "^10.3.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "localforage": "^1.10.0",
         "lucide-react": "^0.383.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2412,6 +2414,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -3853,6 +3873,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4155,6 +4181,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -4174,6 +4209,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "react-router-dom": "^6.23.1",
     "recharts": "^2.12.7",
     "tailwind-merge": "^2.3.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "@use-gesture/react": "^10.3.1",
+    "localforage": "^1.10.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/pages/ExamSession.tsx
+++ b/pages/ExamSession.tsx
@@ -12,6 +12,10 @@ import { Card, CardHeader, CardContent, CardFooter } from '../components/ui/card
 import { cn } from '../lib/utils';
 import { useSound } from '../hooks/useSound';
 import Confetti from '../components/Confetti';
+import ConfirmationModal from '../components/ConfirmationModal';
+import QuickReviewModal from '../components/QuickReviewModal';
+import { useDrag } from '@use-gesture/react';
+import localforage from 'localforage';
 
 interface SessionState {
   questions: ExamQuestion[];
@@ -32,14 +36,66 @@ const ExamSession: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [feedback, setFeedback] = useState<'correct' | 'incorrect' | null>(null);
   const [isAnswered, setIsAnswered] = useState(false);
+  const [timeRemaining, setTimeRemaining] = useState(0);
+  const [isEndExamModalOpen, setIsEndExamModalOpen] = useState(false);
+  const [isQuickReviewOpen, setIsQuickReviewOpen] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
   const playCorrectSound = useSound('/sounds/correct-ding.mp3');
 
-  useEffect(() => {
-    const savedSession = sessionStorage.getItem('examSession');
-    const savedIndex = sessionStorage.getItem('examSessionIndex');
+  const bind = useDrag(({-
+    down,
+    movement: [mx],
+    direction: [xDir],
+    distance,
+    cancel,
+  }) => {
+    if (down && distance > window.innerWidth / 4) {
+      cancel();
+      if (xDir > 0) {
+        changeQuestion(currentIndex - 1);
+      } else {
+        changeQuestion(currentIndex + 1);
+      }
+    }
+  });
 
-    if (location.state?.questions) {
-      const initialState: SessionState = {
+  useEffect(() => {
+    if (sessionState && !isPaused) {
+      const totalTime = sessionState.config.numQuestions * 60;
+      const elapsed = (Date.now() - sessionState.startTime) / 1000;
+      setTimeRemaining(totalTime - elapsed);
+
+      const timer = setInterval(() => {
+        setTimeRemaining(prev => {
+          if (prev <= 1) {
+            clearInterval(timer);
+            handleEndExam();
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+
+      return () => clearInterval(timer);
+    }
+  }, [sessionState?.startTime]);
+
+  useEffect(() => {
+    const resumeSession = async () => {
+      const pausedSession = await localforage.getItem('pausedExamSession');
+      const pausedIndex = await localforage.getItem('pausedExamIndex');
+
+      if (pausedSession && pausedIndex !== null) {
+        setSessionState(pausedSession as SessionState);
+        setCurrentIndex(pausedIndex as number);
+        await localforage.removeItem('pausedExamSession');
+        await localforage.removeItem('pausedExamIndex');
+      } else {
+        const savedSession = sessionStorage.getItem('examSession');
+        const savedIndex = sessionStorage.getItem('examSessionIndex');
+
+        if (location.state?.questions) {
+          const initialState: SessionState = {
         questions: location.state.questions,
         config: location.state.config,
         answers: {},
@@ -77,9 +133,8 @@ const ExamSession: React.FC = () => {
   
   const currentQuestion = sessionState?.questions[currentIndex];
 
-  const handleEndExam = () => {
+  const confirmEndExam = () => {
     if (!sessionState) return;
-    if (!window.confirm('Are you sure you want to end the exam? This action cannot be undone.')) return;
     
     const { questions, config, answers, startTime } = sessionState;
     const timeTaken = Math.floor((Date.now() - startTime) / 1000);
@@ -109,6 +164,10 @@ const ExamSession: React.FC = () => {
     navigate(`/exam/results/${session.id}`);
   };
 
+  const handleEndExam = () => {
+    setIsEndExamModalOpen(true);
+  };
+
   const changeQuestion = (index: number) => {
     if (sessionState && index >= 0 && index < sessionState.questions.length) {
       setCurrentIndex(index);
@@ -123,12 +182,22 @@ const ExamSession: React.FC = () => {
     if (!currentQuestion || isAnswered) return;
     setSessionState(prev => prev ? { ...prev, answers: { ...prev.answers, [currentQuestion.id]: option } } : null);
     setIsAnswered(true);
+    if (navigator.vibrate) {
+      navigator.vibrate(10);
+    }
     if (option === currentQuestion.answer) {
       setFeedback('correct');
       playCorrectSound();
     } else {
       setFeedback('incorrect');
     }
+  };
+
+  const handlePause = async () => {
+    setIsPaused(true);
+    await localforage.setItem('pausedExamSession', sessionState);
+    await localforage.setItem('pausedExamIndex', currentIndex);
+    navigate('/exams');
   };
   
   if (!sessionState || !currentQuestion) {
@@ -142,147 +211,122 @@ const ExamSession: React.FC = () => {
   const isLastQuestion = currentIndex === sessionState.questions.length - 1;
 
   return (
-    <div className="flex flex-col h-screen bg-background font-inter text-foreground">
+    <div className="flex flex-col h-screen text-white" style={{ background: '#0A0A0A', fontFamily: 'SF Pro Display, sans-serif' }}>
       {feedback === 'correct' && <Confetti />}
-      <style>{`
-        .progress-gradient .progress-bar {
-          background-image: linear-gradient(90deg, hsl(var(--secondary)), hsl(var(--primary)));
-        }
-      `}</style>
-      {/* Zone 1: Top Bar */}
-      <header className="flex items-center justify-between p-2 border-b flex-shrink-0 bg-background/80 backdrop-blur-sm h-20">
+
+      {/* Top Bar */}
+      <header className="absolute top-0 left-0 right-0 h-16 bg-black bg-opacity-30 backdrop-blur-sm z-10 flex items-center justify-between px-6">
         <div className="flex items-center gap-4">
-            <div className="relative text-primary">
-                <ProgressRing
-                    progress={100 - (((sessionState.config.durationMinutes * 60) - Math.floor((Date.now() - sessionState.startTime)/1000)) / (sessionState.config.durationMinutes * 60)) * 100}
-                    size={56}
-                    strokeWidth={5}
-                />
-                <div className="absolute inset-0 flex items-center justify-center">
-                    <Timer
-                        initialSeconds={(sessionState.config.durationMinutes * 60) - Math.floor((Date.now() - sessionState.startTime)/1000)}
-                        onTimeUp={handleEndExam}
-                        isPaused={false}
-                        className="text-sm font-mono text-foreground"
-                    />
-                </div>
-            </div>
-            <div className="flex-grow w-48 sm:w-64">
-                <span className="text-sm font-semibold">{`Question ${currentIndex + 1} of ${sessionState.questions.length}`}</span>
-                <Progress value={(currentIndex + 1) / sessionState.questions.length * 100} className="h-2 mt-1 progress-gradient" />
-            </div>
+          <span className="font-bold text-lg" style={{color: '#00A8FF'}}>
+            {`Q ${currentIndex + 1}/${sessionState.questions.length}`}
+          </span>
         </div>
-        <div className="relative">
-          <Button variant="ghost" onClick={() => setIsMenuOpen(prev => !prev)} className="btn-premium-label">
-            Menu
-          </Button>
-          {isMenuOpen && (
-            <div className="absolute right-0 mt-2 w-48 bg-card rounded-lg shadow-xl z-10 border">
-              <ul className="py-1">
-                <li>
-                  <button className="w-full text-left px-4 py-2 text-sm text-foreground hover:bg-muted">Settings</button>
-                </li>
-                <li>
-                  <button className="w-full text-left px-4 py-2 text-sm text-foreground hover:bg-muted">Dark Mode</button>
-                </li>
-                <li>
-                  <button onClick={handleEndExam} className="w-full text-left px-4 py-2 text-sm text-destructive dark:text-red-400 hover:bg-destructive/10">
-                    End Exam
-                  </button>
-                </li>
-              </ul>
-            </div>
-          )}
+        <div className="flex-1 mx-8">
+          <div className="w-full bg-gray-700 rounded-full h-2.5">
+            <div
+              className="h-2.5 rounded-full"
+              style={{
+                width: `${(timeRemaining / (sessionState.config.numQuestions * 60)) * 100}%`,
+                backgroundColor: '#00A8FF',
+                transition: 'width 0.5s linear'
+              }}
+            ></div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={handlePause}>Pause</Button>
+          <Button variant="destructive" onClick={handleEndExam}>End Exam</Button>
         </div>
       </header>
 
-      <div className="flex flex-grow overflow-hidden">
-        {/* Zone 2: Main Question Panel */}
-        <main className="flex-grow p-4 sm:p-6 md:p-8 overflow-y-auto">
-          <div className="max-w-4xl mx-auto">
-            <div key={currentIndex} className="animate-question-change">
-              <Card className="flex-grow flex flex-col shadow-lg border-none bg-card rounded-xl">
-                <CardHeader className="p-6">
-                  <p className="font-serif text-lg sm:text-xl font-bold text-foreground leading-relaxed">{currentQuestion.question}</p>
-              </CardHeader>
-
-              <CardContent className="flex-grow p-6">
-                  <div className="space-y-3">
-                  {currentQuestion.options.map((option, i) => {
-                      const isSelected = sessionState.answers[currentQuestion.id] === option;
-                      const isCorrect = option === currentQuestion.answer;
-                      let feedbackClass = '';
-                      if (isSelected && feedback === 'correct') {
-                        feedbackClass = 'animate-green-pulse bg-success text-success-foreground';
-                      } else if (isSelected && feedback === 'incorrect') {
-                        feedbackClass = 'animate-shake bg-destructive text-destructive-foreground';
-                      } else if (isAnswered && isCorrect) {
-                        feedbackClass = 'bg-success text-success-foreground';
-                      }
-
-                      return (
-                        <Button
-                          key={i}
-                          variant="outline"
-                          onClick={() => handleSelectAnswer(option)}
-                          disabled={isAnswered}
-                          className={cn(
-                            "w-full h-auto justify-start p-4 text-base whitespace-normal rounded-full transition-all duration-200",
-                            "bg-gray-200/50 dark:bg-gray-800/50 border-transparent hover:bg-gray-300/70 dark:hover:bg-gray-700/70 hover:-translate-y-px",
-                            isSelected && "bg-primary text-primary-foreground hover:bg-primary/90",
-                            feedbackClass
-                          )}
-                        >
-                            <span className="font-mono text-sm mr-4 opacity-70">{String.fromCharCode(65 + i)}.</span>
-                            <span className="text-left flex-1">{option}</span>
-                        </Button>
-                      );
-                  })}
-                  </div>
-              </CardContent>
-
-              <CardFooter className="flex justify-between items-center border-t p-4 bg-card/50 rounded-b-xl">
-                <Button variant="outline" className="rounded-full">Mark for Review</Button>
-                <div className="flex gap-2">
-                  <Button onClick={() => changeQuestion(currentIndex - 1)} disabled={currentIndex === 0} variant="outline" className="rounded-full">
-                    <ChevronLeft size={20} /> <span className="hidden sm:inline ml-2">Previous</span>
-                  </Button>
-                  <Button onClick={() => isLastQuestion ? handleEndExam() : changeQuestion(currentIndex + 1)} className={cn("rounded-full btn-gradient", isLastQuestion && "bg-destructive")}>
-                    {isLastQuestion ? 'Finish & Submit' : 'Save & Next'} <ChevronRight size={20} className="ml-2" />
-                  </Button>
-                </div>
-              </CardFooter>
-            </Card>
+      {/* Main Content */}
+      <main {...bind()} className="flex-1 flex items-center justify-center overflow-y-auto p-4 sm:p-6 pt-20 pb-20 touch-none">
+        <div key={currentIndex} className="animate-question-change w-full max-w-lg md:max-w-2xl lg:max-w-4xl">
+          <div
+            className="glass-card"
+            style={{
+              backgroundColor: 'rgba(10, 10, 10, 0.8)',
+              borderRadius: '16px',
+              border: '1px solid rgba(255, 255, 255, 0.1)'
+            }}
+          >
+            <div className="p-6 md:p-8">
+              <p className="text-xl md:text-2xl font-bold leading-relaxed" style={{fontFamily: 'SF Pro Display, sans-serif'}}>
+                {currentQuestion.question}
+              </p>
+            </div>
+            <div className="p-6 md:p-8 grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {currentQuestion.options.map((option, i) => {
+                const isSelected = sessionState.answers[currentQuestion.id] === option;
+                return (
+                  <button
+                    key={i}
+                    className={cn(
+                      "neumorphic-button h-16 text-left p-4 text-lg transition-all duration-200",
+                      isSelected && "bg-blue-500 text-white shadow-none"
+                    )}
+                    style={{
+                      backgroundColor: isSelected ? '#00A8FF' : '#2A2A2A'
+                    }}
+                    onClick={() => handleSelectAnswer(option)}
+                    disabled={isAnswered}
+                  >
+                    <span className="font-mono mr-4 opacity-70">{String.fromCharCode(65 + i)}.</span>
+                    {option}
+                  </button>
+                )
+              })}
             </div>
           </div>
-        </main>
+        </div>
+      </main>
 
-        {/* Zone 3: Right Sidebar */}
-        <aside className="w-full lg:w-80 flex-shrink-0 border-l p-4 flex-col bg-card hidden lg:flex">
-          <h3 className="font-bold text-foreground mb-4 text-center text-lg">Question Navigator</h3>
-          <div className="grid grid-cols-6 gap-2 flex-grow overflow-y-auto content-start p-2 bg-muted/50 rounded-lg">
-            {sessionState.questions.map((q, index) => {
-              const isMarked = sessionState.markedForReview.includes(q.id);
-              const isAnswered = sessionState.answers[q.id] !== undefined;
-              const isCurrent = index === currentIndex;
-
-              let statusClass = 'bg-gray-300/50 dark:bg-gray-700/50 hover:bg-gray-400/50';
-              if (sessionState.visited.includes(q.id) && !isAnswered) statusClass = 'bg-yellow-400/80 dark:bg-yellow-600/80 hover:bg-yellow-500 text-black'; // Skipped
-              if (isAnswered) statusClass = 'bg-primary/90 hover:bg-primary text-primary-foreground'; // Answered
-              if (isMarked) statusClass = 'bg-red-500 dark:bg-red-600 hover:bg-red-600 text-white'; // Marked
-
-              return (
-                <button key={q.id} onClick={() => changeQuestion(index)} className={cn("h-10 w-10 rounded-full flex items-center justify-center font-bold transition-all duration-200", statusClass, isCurrent && 'ring-4 ring-primary/50 ring-offset-2 ring-offset-background')}>
-                  {index + 1}
-                </button>
-              );
-            })}
-          </div>
-          <Button onClick={handleEndExam} variant="destructive" className="w-full mt-4 rounded-full">
-            <Power size={18} className="mr-2"/> End Exam
+      {/* Bottom Bar */}
+      {/* Bottom Bar */}
+      <footer className="absolute bottom-0 left-0 right-0 h-16 bg-black bg-opacity-30 backdrop-blur-sm z-10 flex items-center justify-between px-6">
+        <Button
+          variant="outline"
+          onClick={() => {
+            const isMarked = sessionState.markedForReview.includes(currentQuestion.id);
+            const newMarked = isMarked
+              ? sessionState.markedForReview.filter(id => id !== currentQuestion.id)
+              : [...sessionState.markedForReview, currentQuestion.id];
+            setSessionState(prev => prev ? { ...prev, markedForReview: newMarked } : null);
+          }}
+          style={{ color: sessionState.markedForReview.includes(currentQuestion.id) ? '#00A8FF' : 'white' }}
+        >
+          Flag Question
+        </Button>
+        <div className="flex items-center gap-4">
+          <Button variant="outline" onClick={() => changeQuestion(currentIndex - 1)} disabled={currentIndex === 0}>
+            <ChevronLeft size={20} />
+            Prev
           </Button>
-        </aside>
-      </div>
+          <Button onClick={() => changeQuestion(currentIndex + 1)} disabled={isLastQuestion}>
+            Next
+            <ChevronRight size={20} />
+          </Button>
+        </div>
+        <Button variant="outline" onClick={() => setIsQuickReviewOpen(true)}>Quick Review</Button>
+      </footer>
+
+      <ConfirmationModal
+        isOpen={isEndExamModalOpen}
+        onClose={() => setIsEndExamModalOpen(false)}
+        onConfirm={confirmEndExam}
+        title="End Exam"
+        description="Are you sure you want to end the exam? This action cannot be undone."
+      />
+
+      <QuickReviewModal
+        isOpen={isQuickReviewOpen}
+        onClose={() => setIsQuickReviewOpen(false)}
+        questions={sessionState.questions}
+        answers={sessionState.answers}
+        markedForReview={sessionState.markedForReview}
+        currentIndex={currentIndex}
+        onQuestionSelect={changeQuestion}
+      />
     </div>
   );
 };


### PR DESCRIPTION
This commit revamps the 'Exam Session UI' to create an immersive, distraction-free experience for the user. It introduces a new layout with a full-screen view, a translucent top and bottom bar, and a central glassmorphic question card. The UI is designed to be responsive and optimized for iPad Air.

Key features of the new Exam Session UI:
- Full-screen, immersive layout.
- Top bar with a linear timer, question counter, and 'End Exam' button.
- Main question area with a glassmorphic card and neumorphic option buttons.
- Bottom bar with navigation, flagging, and a 'Quick Review' modal.
- Swipe gestures for question navigation.
- Haptic feedback on answer selection.
- Pause/resume functionality with state saving to IndexedDB.

This commit also addresses feedback from the previous code review for the 'Create Exam Panel':
- The 'Preview Questions' modal is now populated with data.
- The difficulty slider thumb is now styled with the correct color.
- The 'Clear Filters' button now has a red outline.
- The 'Save Preset' icon has been updated to be more appropriate.