### PR TITLE
Fix: Remove duplicate declaration of availableChapters in ExamSetup

### DIFF
--- a/pages/ExamSetup.tsx
+++ b/pages/ExamSetup.tsx
@@ -48,16 +48,6 @@ const ExamSetup: React.FC = () => {
     return [...new Set(chapters)];
   }, [batches, config.subjects]);
 
-  const availableChapters = useMemo(() => {
-    if (config.subjects.length === 0) {
-      return [];
-    }
-    const chapters = batches
-      .filter(b => config.subjects.includes(b.subject))
-      .map(b => b.chapter);
-    return [...new Set(chapters)];
-  }, [batches, config.subjects]);
-
   const filteredQuestions = useMemo(() => {
     return allQuestions.filter(q => {
       const subjectMatch = config.subjects.length === 0 || config.subjects.includes(q.subject);


### PR DESCRIPTION
The `availableChapters` constant was declared twice in `pages/ExamSetup.tsx`, causing a TypeScript error (TS2451) during the build process. This prevented the Netlify deployment from succeeding.

This commit removes the redundant declaration, resolving the build error.