### PR TITLE
feat: update exam session state when tagging questions

### DIFF
--- a/context/ExamContext.tsx
+++ b/context/ExamContext.tsx
@@ -18,6 +18,7 @@ interface ExamContextType {
   startExam: (config: ExamConfig, questions: ExamQuestion[]) => void;
   answerQuestion: (questionId: string, userAnswer: string | null) => void;
   endExam: () => Promise<void>;
+  updateQuestionInSession: (questionId: string, updates: Partial<ExamQuestion>) => void;
   currentQuestion: ExamQuestion | undefined;
   userAnswers: { [questionId: string]: string | null };
   currentQuestionIndex: number;
@@ -91,6 +92,20 @@ export const ExamProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
+  const updateQuestionInSession = (questionId: string, updates: Partial<ExamQuestion>) => {
+    setExamSession(prevSession => {
+      if (!prevSession) return null;
+      return {
+        ...prevSession,
+        questions: prevSession.questions.map(q =>
+          q.questionData.id === questionId
+            ? { ...q, questionData: { ...q.questionData, ...updates } }
+            : q
+        ),
+      };
+    });
+  };
+
   const endExam = useCallback(async () => {
     stopTimer();
     if (!examSession) return;
@@ -143,6 +158,7 @@ export const ExamProvider = ({ children }: { children: ReactNode }) => {
     startExam,
     answerQuestion,
     endExam,
+    updateQuestionInSession,
     currentQuestion,
     userAnswers,
     currentQuestionIndex,

--- a/pages/ExamSession.tsx
+++ b/pages/ExamSession.tsx
@@ -24,6 +24,7 @@ const ExamSession: React.FC = () => {
     answerQuestion,
     setCurrentQuestionIndex,
     endExam,
+    updateQuestionInSession,
   } = useExam();
 
   const { updateQuestion } = useBatches();
@@ -78,9 +79,11 @@ const ExamSession: React.FC = () => {
 
   const toggleTag = (tag: keyof MCQ['tags']) => {
     if (!currentQuestion) return;
+    const newTags = { ...currentQuestion.tags, [tag]: !currentQuestion.tags?.[tag] };
     updateQuestion(currentQuestion.batchId, currentQuestion.id, {
-      tags: { ...currentQuestion.tags, [tag]: !currentQuestion.tags[tag] },
+      tags: newTags,
     });
+    updateQuestionInSession(currentQuestion.id, { tags: newTags });
   };
 
   const toggleMarkForReview = (questionId: string) => {


### PR DESCRIPTION
This commit introduces a new function `updateQuestionInSession` to the `ExamContext`. This function allows updating the data of a question within the current exam session.

The `toggleTag` function in `ExamSession.tsx` has been updated to call this new function. This ensures that when a user tags a question during an exam, the UI reflects the change in real-time. This fixes the bug where tag icons (e.g., bookmark, hard, revise) would not visually update when clicked.